### PR TITLE
Add Docker-based test pipeline

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,15 @@
+name: Docker CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build Docker image
+        run: docker build -t gym-nim .
+      - name: Run tests
+        run: docker run --rm gym-nim

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.6-slim
+WORKDIR /app
+COPY . /app
+RUN pip install --no-cache-dir nose \ 
+    && pip install --no-cache-dir -e .
+CMD ["python", "tests.py"]

--- a/README.md
+++ b/README.md
@@ -5,3 +5,14 @@ An example of a custom environment for https://github.com/openai/gym.
 I want to try out self-play in a Reinforcement Learning context. Rather than the board game environments on openai/gym right now, which are "single-player" by providing a built-in opponent, I want to create an agent that learns a strategy by playing against itself, so it will try to maximize the reward for "player 1" and minimize it for "player 2".
 
 A game that's even simpler than Tic-Tac-Toe/Noughts & Crosses is Nim.
+
+## Docker-based build pipeline
+
+A `Dockerfile` is provided to test the project with the legacy `gym==0.9.1` dependency. Build and run the container to execute the test suite:
+
+```bash
+docker build -t gym-nim .
+docker run --rm gym-nim
+```
+
+This runs `tests.py` inside the container so you can verify that the package still functions with the old dependency.


### PR DESCRIPTION
## Summary
- add Dockerfile to run tests with gym==0.9.1
- add GitHub Actions workflow that builds the docker image and executes tests
- document how to use the Docker pipeline in README

## Testing
- `python tests.py`
- `flake8` *(fails: command not found)*