### PR TITLE
Fix variable scope error and shadowing in qtable.py

### DIFF
--- a/examples/qtable.py
+++ b/examples/qtable.py
@@ -86,15 +86,15 @@ def choose_move(Q, hs, env, om, maximizing_player, bonus):
 
 def train(env):
 
-    asp = env.action_space
-    print (asp)
+    action_space = env.action_space
+    print (action_space)
     
-    os = env.observation_space
-    print (os)
+    observation_space = env.observation_space
+    print (observation_space)
     
     
     # Initialize table with all zeros
-    Q = np.zeros([os.n, asp.n])
+    Q = np.zeros([observation_space.n, action_space.n])
     # Set learning parameters
     lr = .85  # learning rate
     y = .99  # discount factor.
@@ -119,7 +119,7 @@ def train(env):
             # Choose an action by greedily (with noise) picking from Q table
       #         print ("s: ", s)
     #         print ("hs: ", hs)
-            pick = np.random.randn(1, asp.n)
+            pick = np.random.randn(1, action_space.n)
             puck = (1. / (i + 1))
             bonus = pick * puck
      #       print ("pick: ", pick, ", puck: ", puck, ", bonus: ", bonus)
@@ -160,8 +160,8 @@ def train(env):
                 q.put(it)
             if (i % 500 == 0):
                 print (rolling_rAll / ROLLING_ELEMENTS)
-                for i in range(os.n):
-                    for j in range (asp.n):
+                for i in range(observation_space.n):
+                    for j in range (action_space.n):
                         q2 = Q[i][j]
                         if (q2 != 0):
                             print (i, ", ", j, ": ",q2)
@@ -179,8 +179,11 @@ env = gym.make('nim-v0')
 Q = train(env)
 
 print (Q)
-for i in range(os.n):
-    for j in range (asp.n):
+# Access spaces directly from env since os and asp are local to train()
+observation_space = env.observation_space
+action_space = env.action_space
+for i in range(observation_space.n):
+    for j in range(action_space.n):
         q = Q[i][j]
         if (q != 0):
             print (i, ", ", j, ": ",q)


### PR DESCRIPTION
## Description

Fixes the variable scope error in `examples/qtable.py` that was causing a `NameError` when trying to access the Q-table values after training.

Closes #7

## Changes

- **Fix scope error**: Variables `os` and `asp` were defined inside the `train()` function but accessed outside of it
- **Rename variables**: Changed `os` → `observation_space` and `asp` → `action_space` to avoid shadowing the standard library `os` module
- **Access environment spaces**: When needed outside the train function, access `env.observation_space` and `env.action_space` directly

## Testing

- [x] Example now runs without errors
- [x] Training completes successfully
- [x] Q-table values are displayed correctly at the end
- [x] No more `NameError` when accessing final results

## Code Quality

- Eliminates shadowing of standard library module
- Uses clearer, more descriptive variable names
- Maintains all original functionality

The qtable.py example now works as intended and can be used for Q-learning experiments with the Nim environment.