### PR TITLE
Fix gymnasium environment metadata warning

### DIFF
--- a/gym_nim/envs/nim_env.py
+++ b/gym_nim/envs/nim_env.py
@@ -45,7 +45,7 @@ class NimEnv(gym.Env):
     >>> print(state['on_move'])
     2
     """
-    metadata = {'render.modes': ['human']}
+    metadata = {'render_modes': ['human']}
 
     def __init__(self):
         # Action space: tuple of (pile_index, pieces_to_take)


### PR DESCRIPTION
## Description
Fixes the gymnasium metadata warning by updating the metadata dictionary to use the correct key format.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
- [x] All existing tests pass
- [x] Manually tested the changes

## Changes
- Changed `'render.modes'` to `'render_modes'` in metadata dict to match Gymnasium API expectations

## Related Issues
Fixes #20