### PR TITLE
Fix observation space mismatch: dict vs int expected

### DIFF
--- a/gym_nim/envs/nim_env.py
+++ b/gym_nim/envs/nim_env.py
@@ -49,10 +49,19 @@ class NimEnv(gym.Env):
 
     def __init__(self):
         # Action space: tuple of (pile_index, pieces_to_take)
-        # We'll validate actions manually since old gym doesn't support our use case well
+        # We'll validate actions manually since gym doesn't support tuple actions directly
         self.action_space = spaces.Discrete(9)  # Placeholder, we'll validate manually
-        # Observation space: simplified for old gym version
-        self.observation_space = spaces.Discrete(8*8*8*2)  # flattened board + player
+        
+        # Observation space: Dict with board state and current player
+        self.observation_space = spaces.Dict({
+            'board': spaces.Box(low=0, high=7, shape=(3,), dtype=np.int32),
+            'on_move': spaces.Discrete(3, start=1)  # Player 1 or 2
+        })
+        
+        # For backward compatibility with Q-learning example that expects .n attribute
+        # This represents the flattened state space size
+        self.observation_space.n = 8 * 8 * 8 * 2  # All possible board states * players
+        
         self.state = None
     def step(self, action):
         """Execute one time step within the environment.


### PR DESCRIPTION
## Description
Fixes the gymnasium observation space warning by properly declaring the observation space as a Dict to match the actual observations returned by the environment.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
- [x] All existing tests pass
- [x] Manually verified warning is resolved
- [x] Backward compatibility maintained

## Changes
- Changed observation space from `Discrete(8*8*8*2)` to proper `Dict` space
- Added `board` as Box space and `on_move` as Discrete space
- Maintained backward compatibility by adding `.n` attribute for Q-learning example

## Related Issues
Fixes #21