### PR TITLE
Fix pytest.mark.slow unknown marker warning

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -4,3 +4,5 @@ python_files = test_*.py
 python_classes = Test*
 python_functions = test_*
 addopts = -v --cov=gym_nim --cov-report=html --cov-report=term-missing
+markers =
+    slow: marks tests as slow (deselect with '-m "not slow"')


### PR DESCRIPTION
## Description
Fixes the pytest unknown marker warning by properly registering the `slow` marker in pytest.ini.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
- [x] All existing tests pass
- [x] Manually verified warning is resolved
- [x] Slow tests can now be filtered with `-m "not slow"`

## Changes
- Added `markers` section to pytest.ini
- Registered `slow` marker with description

## Related Issues
Fixes #19